### PR TITLE
feat: add ephemeral PVC option for milvus data and log volumes

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.6.1"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 5.0.2
+version: 5.1.0
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.6.1"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 5.1.0
+version: 5.0.3-vectara.1
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/templates/_helpers.tpl
+++ b/charts/milvus/templates/_helpers.tpl
@@ -246,3 +246,78 @@ false
     {{- end -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+milvus.logVolume renders the pod volume entry for milvus log storage.
+Precedence:
+  1. existingClaim set -> reference that PVC (user-managed).
+  2. ephemeral: true   -> generic ephemeral volume (inline PVC bound to
+     the pod lifecycle, K8s >= 1.21).
+  3. default           -> named PersistentVolumeClaim from pvc.yaml.
+*/}}
+{{- define "milvus.logVolume" -}}
+{{- $pvc := .Values.log.persistence.persistentVolumeClaim -}}
+- name: milvus-logs-disk
+{{- if and $pvc.ephemeral (not $pvc.existingClaim) }}
+  ephemeral:
+    volumeClaimTemplate:
+      metadata:
+        labels:
+          {{- include "milvus.matchLabels" . | nindent 10 }}
+      spec:
+        accessModes:
+          - {{ $pvc.accessModes | quote }}
+        {{- if $pvc.storageClass }}
+        {{- if eq "-" $pvc.storageClass }}
+        storageClassName: ""
+        {{- else }}
+        storageClassName: {{ $pvc.storageClass }}
+        {{- end }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ $pvc.size }}
+{{- else }}
+  persistentVolumeClaim:
+    claimName: {{ $pvc.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+{{- end }}
+{{- end -}}
+
+{{/*
+milvus.standaloneDataVolume renders the pod volume entry for the
+standalone milvus data disk.
+Precedence:
+  1. persistence disabled -> emptyDir (preserves existing behavior).
+  2. existingClaim set    -> reference that PVC.
+  3. ephemeral: true      -> generic ephemeral volume.
+  4. default              -> named PersistentVolumeClaim from pvc.yaml.
+*/}}
+{{- define "milvus.standaloneDataVolume" -}}
+{{- $pvc := .Values.standalone.persistence.persistentVolumeClaim -}}
+- name: milvus-data-disk
+{{- if not .Values.standalone.persistence.enabled }}
+  emptyDir: {}
+{{- else if and $pvc.ephemeral (not $pvc.existingClaim) }}
+  ephemeral:
+    volumeClaimTemplate:
+      metadata:
+        labels:
+          {{- include "milvus.matchLabels" . | nindent 10 }}
+      spec:
+        accessModes:
+          - {{ $pvc.accessModes | quote }}
+        {{- if $pvc.storageClass }}
+        {{- if eq "-" $pvc.storageClass }}
+        storageClassName: ""
+        {{- else }}
+        storageClassName: {{ $pvc.storageClass }}
+        {{- end }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ $pvc.size }}
+{{- else }}
+  persistentVolumeClaim:
+    claimName: {{ $pvc.existingClaim | default (printf "%s" (include "milvus.fullname" . | trunc 58)) }}
+{{- end }}
+{{- end -}}

--- a/charts/milvus/templates/datacoord-deployment.yaml
+++ b/charts/milvus/templates/datacoord-deployment.yaml
@@ -211,9 +211,7 @@ spec:
           name: {{ template "milvus.fullname" . }}
           {{- end }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       - name: tools
         emptyDir: {}

--- a/charts/milvus/templates/datanode-deployment.yaml
+++ b/charts/milvus/templates/datanode-deployment.yaml
@@ -201,9 +201,7 @@ spec:
           name: {{ template "milvus.fullname" . }}
           {{- end }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       - name: tools
         emptyDir: {}

--- a/charts/milvus/templates/indexcoord-deployment.yaml
+++ b/charts/milvus/templates/indexcoord-deployment.yaml
@@ -211,9 +211,7 @@ spec:
           name: {{ template "milvus.fullname" . }}
           {{- end }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       - name: tools
         emptyDir: {}

--- a/charts/milvus/templates/indexnode-deployment.yaml
+++ b/charts/milvus/templates/indexnode-deployment.yaml
@@ -220,9 +220,7 @@ spec:
           name: {{ template "milvus.fullname" . }}
           {{- end }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       - name: tools
         emptyDir: {}

--- a/charts/milvus/templates/mixcoord-deployment.yaml
+++ b/charts/milvus/templates/mixcoord-deployment.yaml
@@ -204,9 +204,7 @@ spec:
           name: {{ template "milvus.fullname" . }}
           {{- end }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       - name: tools
         emptyDir: {}

--- a/charts/milvus/templates/proxy-deployment.yaml
+++ b/charts/milvus/templates/proxy-deployment.yaml
@@ -206,9 +206,7 @@ spec:
           name: {{ template "milvus.fullname" . }}
           {{- end }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       - name: tools
         emptyDir: {}

--- a/charts/milvus/templates/pvc.yaml
+++ b/charts/milvus/templates/pvc.yaml
@@ -1,6 +1,6 @@
 {{- if not .Values.cluster.enabled }}
 {{- $pvc := .Values.standalone.persistence.persistentVolumeClaim -}}
-{{- if and .Values.standalone.persistence.enabled (not $pvc.existingClaim) }}
+{{- if and .Values.standalone.persistence.enabled (not $pvc.existingClaim) (not $pvc.ephemeral) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -29,7 +29,7 @@ spec:
 {{- end }}
 
 {{- $pvc := .Values.log.persistence.persistentVolumeClaim -}}
-{{- if and .Values.log.persistence.enabled (not $pvc.existingClaim)}}
+{{- if and .Values.log.persistence.enabled (not $pvc.existingClaim) (not $pvc.ephemeral) }}
 
 ---
 

--- a/charts/milvus/templates/querycoord-deployment.yaml
+++ b/charts/milvus/templates/querycoord-deployment.yaml
@@ -211,9 +211,7 @@ spec:
           name: {{ template "milvus.fullname" . }}
           {{- end }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       - name: tools
         emptyDir: {}

--- a/charts/milvus/templates/querynode-deployment.yaml
+++ b/charts/milvus/templates/querynode-deployment.yaml
@@ -216,9 +216,7 @@ spec:
           name: {{ template "milvus.fullname" . }}
           {{- end }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       - name: tools
         emptyDir: {}

--- a/charts/milvus/templates/rootcoord-deployment.yaml
+++ b/charts/milvus/templates/rootcoord-deployment.yaml
@@ -211,9 +211,7 @@ spec:
           name: {{ template "milvus.fullname" . }}
           {{- end }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       - name: tools
         emptyDir: {}

--- a/charts/milvus/templates/standalone-deployment.yaml
+++ b/charts/milvus/templates/standalone-deployment.yaml
@@ -210,17 +210,9 @@ spec:
           {{- else }}
           name: {{ template "milvus.fullname" . }}
           {{- end }}
-      - name: milvus-data-disk
-        {{- if .Values.standalone.persistence.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ .Values.standalone.persistence.persistentVolumeClaim.existingClaim | default (printf "%s" (include "milvus.fullname" . | trunc 58)) }}
-        {{- else }}
-        emptyDir: {}
-        {{- end }}
+      {{- include "milvus.standaloneDataVolume" . | nindent 6 }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       {{- if .Values.standalone.disk.enabled }}
       - name: disk

--- a/charts/milvus/templates/streamingnode-deployment.yaml
+++ b/charts/milvus/templates/streamingnode-deployment.yaml
@@ -202,9 +202,7 @@ spec:
           name: {{ template "milvus.fullname" . }}
           {{- end }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       - name: tools
         emptyDir: {}

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -203,6 +203,13 @@ log:
       helm.sh/resource-policy: keep
     persistentVolumeClaim:
       existingClaim: ""
+      ## If true, use a generic ephemeral volume (inline PVC bound to the pod
+      ## lifecycle) instead of a named PersistentVolumeClaim. The volume is
+      ## dynamically provisioned when the pod starts and deleted with the pod.
+      ## Requires Kubernetes >= 1.21 (GA in 1.23).
+      ## Ignored when existingClaim is set (existingClaim wins).
+      ##
+      ephemeral: false
       ## Milvus Logs Persistent Volume Storage Class
       ## If defined, storageClassName: <storageClass>
       ## If set to "-", storageClassName: "", which disables dynamic provisioning
@@ -260,6 +267,13 @@ standalone:
       helm.sh/resource-policy: keep
     persistentVolumeClaim:
       existingClaim: ""
+      ## If true, use a generic ephemeral volume (inline PVC bound to the pod
+      ## lifecycle) instead of a named PersistentVolumeClaim. The volume is
+      ## dynamically provisioned when the pod starts and deleted with the pod.
+      ## Requires Kubernetes >= 1.21 (GA in 1.23).
+      ## Ignored when existingClaim is set (existingClaim wins).
+      ##
+      ephemeral: false
       ## Milvus Persistent Volume Storage Class
       ## If defined, storageClassName: <storageClass>
       ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
Adds persistentVolumeClaim.ephemeral (default false) to both standalone.persistence and log.persistence. When true, pods use a generic ephemeral volume (inline PVC bound to the pod lifecycle) instead of a named PersistentVolumeClaim. Requires Kubernetes >= 1.21.

Precedence: existingClaim > ephemeral > default named PVC. If both existingClaim and ephemeral are set, existingClaim wins -- consistent with how pvc.yaml already gates PVC creation on (not existingClaim). Defaults preserve existing behavior; default render is byte-identical to master.

Upstream (zilliztech/milvus-helm at 5.0.22 / Milvus 2.6.18) does not have this option.

- new helpers: milvus.logVolume, milvus.standaloneDataVolume
- pvc.yaml skips named PVC creation when ephemeral=true and no existingClaim
- all 11 deployment templates emit the helper-rendered volume entry

## What this PR does / why we need it:

## Checklist
[Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields.]
- [ ] Chart Version bumped
- [ ] Variables are documented in the README.md
- [ ] Title of the PR starts with chart name (e.g. `[mychartname]`)
- [ ] PR only contains changes for one chart
