### PR TITLE
feat(milvus): ephemeral PVCs and Chainguard etcd (4.2.52-iamguard)

### DIFF
--- a/charts/milvus/Chart.yaml
+++ b/charts/milvus/Chart.yaml
@@ -3,7 +3,7 @@ name: milvus
 appVersion: "2.5.13"
 kubeVersion: "^1.10.0-0"
 description: Milvus is an open-source vector database built to power AI applications and vector similarity search.
-version: 4.2.51
+version: 4.2.52-iamguard
 keywords:
   - milvus
   - elastic

--- a/charts/milvus/requirements.yaml
+++ b/charts/milvus/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: etcd
   version: 12.0.19
-  repository: oci://cgr.dev/vectara.com/iamguarded-charts/etcd
+  repository: oci://cgr.dev/vectara.com/iamguarded-charts
   condition: etcd.enabled
   tags:
     - etcd

--- a/charts/milvus/requirements.yaml
+++ b/charts/milvus/requirements.yaml
@@ -1,7 +1,7 @@
 dependencies:
 - name: etcd
-  version: 11.1.5
-  repository: https://raw.githubusercontent.com/bitnami/charts/archive-full-index/bitnami
+  version: 12.0.19
+  repository: oci://cgr.dev/vectara.com/iamguarded-charts/etcd
   condition: etcd.enabled
   tags:
     - etcd

--- a/charts/milvus/templates/_helpers.tpl
+++ b/charts/milvus/templates/_helpers.tpl
@@ -231,3 +231,78 @@ false
 {{- toYaml .Values.queryNode.podLabels }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+milvus.logVolume renders the pod volume entry for milvus log storage.
+Precedence:
+  1. existingClaim set -> reference that PVC (user-managed).
+  2. ephemeral: true   -> generic ephemeral volume (inline PVC bound to
+     the pod lifecycle, K8s >= 1.21).
+  3. default           -> named PersistentVolumeClaim from pvc.yaml.
+*/}}
+{{- define "milvus.logVolume" -}}
+{{- $pvc := .Values.log.persistence.persistentVolumeClaim -}}
+- name: milvus-logs-disk
+{{- if and $pvc.ephemeral (not $pvc.existingClaim) }}
+  ephemeral:
+    volumeClaimTemplate:
+      metadata:
+        labels:
+          {{- include "milvus.matchLabels" . | nindent 10 }}
+      spec:
+        accessModes:
+          - {{ $pvc.accessModes | quote }}
+        {{- if $pvc.storageClass }}
+        {{- if eq "-" $pvc.storageClass }}
+        storageClassName: ""
+        {{- else }}
+        storageClassName: {{ $pvc.storageClass }}
+        {{- end }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ $pvc.size }}
+{{- else }}
+  persistentVolumeClaim:
+    claimName: {{ $pvc.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+{{- end }}
+{{- end -}}
+
+{{/*
+milvus.standaloneDataVolume renders the pod volume entry for the
+standalone milvus data disk.
+Precedence:
+  1. persistence disabled -> emptyDir (preserves existing behavior).
+  2. existingClaim set    -> reference that PVC.
+  3. ephemeral: true      -> generic ephemeral volume.
+  4. default              -> named PersistentVolumeClaim from pvc.yaml.
+*/}}
+{{- define "milvus.standaloneDataVolume" -}}
+{{- $pvc := .Values.standalone.persistence.persistentVolumeClaim -}}
+- name: milvus-data-disk
+{{- if not .Values.standalone.persistence.enabled }}
+  emptyDir: {}
+{{- else if and $pvc.ephemeral (not $pvc.existingClaim) }}
+  ephemeral:
+    volumeClaimTemplate:
+      metadata:
+        labels:
+          {{- include "milvus.matchLabels" . | nindent 10 }}
+      spec:
+        accessModes:
+          - {{ $pvc.accessModes | quote }}
+        {{- if $pvc.storageClass }}
+        {{- if eq "-" $pvc.storageClass }}
+        storageClassName: ""
+        {{- else }}
+        storageClassName: {{ $pvc.storageClass }}
+        {{- end }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ $pvc.size }}
+{{- else }}
+  persistentVolumeClaim:
+    claimName: {{ $pvc.existingClaim | default (printf "%s" (include "milvus.fullname" . | trunc 58)) }}
+{{- end }}
+{{- end -}}

--- a/charts/milvus/templates/datacoord-deployment.yaml
+++ b/charts/milvus/templates/datacoord-deployment.yaml
@@ -211,9 +211,7 @@ spec:
           name: {{ template "milvus.fullname" . }}
           {{- end }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       - name: tools
         emptyDir: {}

--- a/charts/milvus/templates/datanode-deployment.yaml
+++ b/charts/milvus/templates/datanode-deployment.yaml
@@ -205,9 +205,7 @@ spec:
           name: {{ template "milvus.fullname" . }}
           {{- end }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       - name: tools
         emptyDir: {}

--- a/charts/milvus/templates/indexcoord-deployment.yaml
+++ b/charts/milvus/templates/indexcoord-deployment.yaml
@@ -211,9 +211,7 @@ spec:
           name: {{ template "milvus.fullname" . }}
           {{- end }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       - name: tools
         emptyDir: {}

--- a/charts/milvus/templates/indexnode-deployment.yaml
+++ b/charts/milvus/templates/indexnode-deployment.yaml
@@ -217,9 +217,7 @@ spec:
           name: {{ template "milvus.fullname" . }}
           {{- end }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       - name: tools
         emptyDir: {}

--- a/charts/milvus/templates/mixcoord-deployment.yaml
+++ b/charts/milvus/templates/mixcoord-deployment.yaml
@@ -208,9 +208,7 @@ spec:
           name: {{ template "milvus.fullname" . }}
           {{- end }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       - name: tools
         emptyDir: {}

--- a/charts/milvus/templates/proxy-deployment.yaml
+++ b/charts/milvus/templates/proxy-deployment.yaml
@@ -210,9 +210,7 @@ spec:
           name: {{ template "milvus.fullname" . }}
           {{- end }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       - name: tools
         emptyDir: {}

--- a/charts/milvus/templates/pvc.yaml
+++ b/charts/milvus/templates/pvc.yaml
@@ -1,6 +1,6 @@
 {{- if not .Values.cluster.enabled }}
 {{- $pvc := .Values.standalone.persistence.persistentVolumeClaim -}}
-{{- if and .Values.standalone.persistence.enabled (not $pvc.existingClaim) }}
+{{- if and .Values.standalone.persistence.enabled (not $pvc.existingClaim) (not $pvc.ephemeral) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -29,7 +29,7 @@ spec:
 {{- end }}
 
 {{- $pvc := .Values.log.persistence.persistentVolumeClaim -}}
-{{- if and .Values.log.persistence.enabled (not $pvc.existingClaim)}}
+{{- if and .Values.log.persistence.enabled (not $pvc.existingClaim) (not $pvc.ephemeral) }}
 
 ---
 

--- a/charts/milvus/templates/querycoord-deployment.yaml
+++ b/charts/milvus/templates/querycoord-deployment.yaml
@@ -211,9 +211,7 @@ spec:
           name: {{ template "milvus.fullname" . }}
           {{- end }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       - name: tools
         emptyDir: {}

--- a/charts/milvus/templates/querynode-deployment.yaml
+++ b/charts/milvus/templates/querynode-deployment.yaml
@@ -220,9 +220,7 @@ spec:
           name: {{ template "milvus.fullname" . }}
           {{- end }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       - name: tools
         emptyDir: {}

--- a/charts/milvus/templates/rootcoord-deployment.yaml
+++ b/charts/milvus/templates/rootcoord-deployment.yaml
@@ -211,9 +211,7 @@ spec:
           name: {{ template "milvus.fullname" . }}
           {{- end }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       - name: tools
         emptyDir: {}

--- a/charts/milvus/templates/standalone-deployment.yaml
+++ b/charts/milvus/templates/standalone-deployment.yaml
@@ -213,17 +213,9 @@ spec:
           {{- else }}
           name: {{ template "milvus.fullname" . }}
           {{- end }}
-      - name: milvus-data-disk
-        {{- if .Values.standalone.persistence.enabled }}
-        persistentVolumeClaim:
-          claimName: {{ .Values.standalone.persistence.persistentVolumeClaim.existingClaim | default (printf "%s" (include "milvus.fullname" . | trunc 58)) }}
-        {{- else }}
-        emptyDir: {}
-        {{- end }}
+      {{- include "milvus.standaloneDataVolume" . | nindent 6 }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       {{- if .Values.standalone.disk.enabled }}
       - name: disk

--- a/charts/milvus/templates/streamingnode-deployment.yaml
+++ b/charts/milvus/templates/streamingnode-deployment.yaml
@@ -204,9 +204,7 @@ spec:
           name: {{ template "milvus.fullname" . }}
           {{- end }}
       {{- if .Values.log.persistence.enabled }}
-      - name: milvus-logs-disk
-        persistentVolumeClaim:
-          claimName: {{ .Values.log.persistence.persistentVolumeClaim.existingClaim | default (printf "%s-logs" (include "milvus.fullname" . | trunc 58)) }}
+      {{- include "milvus.logVolume" . | nindent 6 }}
       {{- end }}
       - name: tools
         emptyDir: {}

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -702,8 +702,8 @@ etcd:
   pdb:
     create: false
   image:
-    repository: "milvusdb/etcd"
-    tag: "3.5.18-r1"
+    repository: "cgr.dev/vectara.com/etcd-iamguarded"
+    tag: "latest"
     pullPolicy: IfNotPresent
 
   service:

--- a/charts/milvus/values.yaml
+++ b/charts/milvus/values.yaml
@@ -207,6 +207,13 @@ log:
       helm.sh/resource-policy: keep
     persistentVolumeClaim:
       existingClaim: ""
+      ## If true, use a generic ephemeral volume (inline PVC bound to the pod
+      ## lifecycle) instead of a named PersistentVolumeClaim. The volume is
+      ## dynamically provisioned when the pod starts and deleted with the pod.
+      ## Requires Kubernetes >= 1.21 (GA in 1.23).
+      ## Ignored when existingClaim is set (existingClaim wins).
+      ##
+      ephemeral: false
       ## Milvus Logs Persistent Volume Storage Class
       ## If defined, storageClassName: <storageClass>
       ## If set to "-", storageClassName: "", which disables dynamic provisioning
@@ -264,6 +271,13 @@ standalone:
       helm.sh/resource-policy: keep
     persistentVolumeClaim:
       existingClaim: ""
+      ## If true, use a generic ephemeral volume (inline PVC bound to the pod
+      ## lifecycle) instead of a named PersistentVolumeClaim. The volume is
+      ## dynamically provisioned when the pod starts and deleted with the pod.
+      ## Requires Kubernetes >= 1.21 (GA in 1.23).
+      ## Ignored when existingClaim is set (existingClaim wins).
+      ##
+      ephemeral: false
       ## Milvus Persistent Volume Storage Class
       ## If defined, storageClassName: <storageClass>
       ## If set to "-", storageClassName: "", which disables dynamic provisioning


### PR DESCRIPTION
## Summary

Backports the ephemeral PVC option for milvus data and log volumes from the master-based [PR #3](https://github.com/vectara/milvus-helm/pull/3) onto the live `feat/vectara/milvus-2513` iamguard chart line, and bumps the chart to `4.2.52-iamguard`.

PR #3 was based on `master` and rebased the chart to `5.0.3-vectara.1` / milvus 2.6 / streaming-node, which would have dropped the manual bitnami → chainguard etcd subchart rewrites that the published `4.2.51-iamguard` chart depends on. Closing #3 in favor of this PR; the 5.x migration with iamguard ports will be a separate effort.

### Changes
- `feat: add ephemeral PVC option for milvus data and log volumes` (cherry-pick of 8715ac695a)
  - new helpers `milvus.logVolume`, `milvus.standaloneDataVolume`
  - `pvc.yaml` skips named PVC creation when `ephemeral=true` and no `existingClaim`
  - all 11 deployment templates emit the helper-rendered volume entry
  - precedence: `existingClaim` > `ephemeral` > default named PVC
  - default render preserved (byte-identical when ephemeral=false / unset)
- `chore: bump milvus chart to 4.2.52-iamguard`

### Why -iamguard suffix
Provisioning chart's `constant-values/milvus.yaml:408,428` branches on whether `chartVersion` contains `-iamguard` to choose between the chainguard `etcd-iamguarded` image and vanilla `bitnami/etcd`. Keeping the suffix preserves the chainguard path.

## Test plan
- [ ] CI passes
- [ ] Sync pipeline publishes `helm/vectara/milvus:4.2.52-iamguard` to ECR
- [ ] Provisioning bump PR (replacement for #2452) lands and renders the new chart with `ephemeral: true` on a test instance
- [ ] Confirm default render (ephemeral unset) is unchanged from `4.2.51-iamguard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)